### PR TITLE
Revisão da página de contatos [#4]

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -5,58 +5,24 @@ title: "Entre em Contato"
 description: "Entre em contato com nosso time de colaboradores frequentes caso tenha dúvidas, problemas ou sugestões."
 ---
 
-## Time de Tradução & Desenvolvimento
-
 É muito importante para nós estarmos atualizados com as últimas mudanças no mundo da privacidade. Se você possui alguma recomendação para melhorar este site, ou algum problema, não hesite em entrar em contato!
+
+## Desenvolvimento no GitHub
 
 [<i class="fab fa-github"></i> Abra um issue ou requisição pull no GitHub](https://github.com/PrivacidadeDigital/privacidade.digital/issues)
 
-Para manter a transparência no desenvolvimento do projeto, a inclusão de softwares e mudanças no site precisam ser discutidas no GitHub anteriormente. Por favor não entre em contato com algum dos nossos colaboradores diretamente para discutir uma mudança editorial no site, sempre utilize o GitHub primeiro.
+Para manter a transparência no desenvolvimento dos projetos desta comunidade, a inclusão de softwares e mudanças neste site precisam ser discutidas no GitHub anteriormente, mesmo que haja uma discussão externa sobre o assunto.
+
+## Grupos de Conversa
 
 <span class="text-success"><i class="fas fa-comment"></i> Novo:</span> Agora nós usamos Matrix! Junte-se a nós em `#privacidade.digital-geral:matrix.org` para conversar conosco e outros membros sobre este site e privacidade em geral. Se você precisar de uma conta Matrix, você pode criá-la em [Riot.im](https://riot.im/) ou qualquer cliente Matrix! Se você prefere XMPP, recomendamos que use [a ponte XMPP do Matrix.org pra participar do chat](https://conversations.im/j/%23privacidade.digital-geral%23matrix.org@bridge.xmpp.matrix.org).
+
+## Redes Sociais
+
+[<i class="fab fa-twitter"></i> Acompanhe nossos tweets](https://twitter.com/PrivacidadeJa)
+
+## Email
 
 Caso prefira entrar em contato por email, envie sua mensagem para o seguinte endereço:
 <p><a class="btn btn-primary bg-success border-0 mb-1"
       href="mailto:contato@privacidade.digital">contato@privacidade.digital</a></p>
-
-<!-- <div class="row">
-  <div class="col-12 col-sm-7 col-md-8 col-lg-9">
-    <div class="card mb-4">
-      <div class="card-header">
-        Emails de Contato
-      </div>
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item"><strong>Abuso:</strong> abuse at privacytools dot io</li>
-        <li class="list-group-item"><strong>Webmaster:</strong> webmaster at privacytools dot io</li>
-        <li class="list-group-item"><strong>Hostmaster:</strong> hostmaster at privacytools dot io</li>
-        <li class="list-group-item"><strong>Postmaster:</strong> postmaster at privacytools dot io</li>
-        <li class="list-group-item"><strong>Segurança:</strong> security at privacytools dot io</li>
-      </ul>
-    </div>
-    <div class="card mb-4">
-      <div class="card-header">
-        GitHub Issues
-      </div>
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item"><strong>Searx Issues:</strong> <a href="https://github.com/privacytoolsIO/search">github.com/privacytoolsIO/search</a></li>
-        <li class="list-group-item"><strong>Website Issues:</strong> <a href="https://github.com/privacytoolsIO/privacytools.io">github.com/privacytoolsIO/privacytools.io</a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="col-12 col-sm-5 col-md-4 col-lg-3">
-    <div class="col-8 col-sm-12">
-      <div class="card text-white bg-dark">
-        <img class="card-img-top" src="/assets/img/layout/jonah.png" alt="Card image cap">
-        <div class="card-body">
-          <h5 class="card-title">Jonah</h5>
-          <h6 class="card-subtitle mb-2 text-light">Administrador Líder</h6>
-        </div>
-        <ul class="list-group list-group-flush">
-          <li class="list-group-item text-white bg-dark"><a href="mailto:jonah@privacytools.io" class="card-link text-white">Email</a></li>
-          <li class="list-group-item text-white bg-dark"><a href="https://keybase.io/jonaharagon/pgp_keys.asc?fingerprint=9bd822880e2784ee5c929cd6db49bb255b868219" class="card-link text-white">GPG</a></li>
-          <li class="list-group-item text-white bg-dark"><a href="https://github.com/JonahAragon" class="card-link text-white">GitHub</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</div> -->

--- a/contact.md
+++ b/contact.md
@@ -15,11 +15,7 @@ Para manter a transparência no desenvolvimento dos projetos desta comunidade, a
 
 ## Grupos de Conversa
 
-<span class="text-success"><i class="fas fa-comment"></i> Novo:</span> Agora nós usamos Matrix! Junte-se a nós em `#privacidade.digital-geral:matrix.org` para conversar conosco e outros membros sobre este site e privacidade em geral. Se você precisar de uma conta Matrix, você pode criá-la em [Riot.im](https://riot.im/) ou qualquer cliente Matrix! Se você prefere XMPP, recomendamos que use [a ponte XMPP do Matrix.org pra participar do chat](https://conversations.im/j/%23privacidade.digital-geral%23matrix.org@bridge.xmpp.matrix.org).
-
-## Redes Sociais
-
-[<i class="fab fa-twitter"></i> Acompanhe nossos tweets](https://twitter.com/PrivacidadeJa)
+<span class="text-success"><i class="fas fa-comment"></i> Novo:</span> Agora nós usamos Matrix! Junte-se a nós em `#privacidade.digital-geral:matrix.org` para conversar conosco e outros membros sobre este site e privacidade em geral. Se você precisar de uma conta Matrix, você pode criá-la em [Riot.im](https://riot.im/) ou qualquer cliente Matrix! Se você prefere XMPP, recomendamos que use [a ponte XMPP do Matrix.org pra participar do chat](https://conversations.im/j/%23privacidade.digital-geral:matrix.org@bridge.xmpp.matrix.org).
 
 ## Email
 


### PR DESCRIPTION
* Agora a página é dividida em diferentes métodos de contatos: plataforma de desenvolvimento (GitHub), grupos de conversa (Matrix) e email.
* Mudança no aviso sobre transparência do desenvolvimento do site.
* Remoção de comentário do arquivo `contact.md`.