### PR TITLE
Mudanças na política de privacidade do site [#4]

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -2,12 +2,12 @@
 layout: page
 permalink: /politica-de-privacidade/
 title: "Política de Privacidade"
-description: "A Política de Privacidade explica quais informações privacidade.digital e suas entidades coletam sobre seus usuários, o que nós fazemos com essas informações, e como nós lidamos com o conteúdo que voce põem em nossos produtos e serviços."
+description: "A política de privacidade explica quais informações o time responsável pelo site www.privacidade.digital e suas entidades coletam sobre seus visitantes, o que nós fazemos com essas informações, e como nós lidamos com o conteúdo que você gera utilizando nossos produtos e serviços."
 ---
 
 <h2>Escopo da Política de Privacidade</h2>
 
-<p>Esta Política de Privacidade se refere às informações que obtemos através dos serviços que provemos através de um dispositivo ou quando você interage com nossos serviços web oficiais diretamente.</p>
+<p>Esta política de privacidade se refere às informações que obtemos através dos serviços que oferecemos, dos quais você utiliza através de um Dispositivo, ou quando você interage com nossos serviços web oficiais por outros meios.</p>
 <p>Nossos serviços incluem:</p>
 <ul>
   <li>Sites (www.privacidade.digital e seus subdomínios *.privacidade.digital)</li>
@@ -15,86 +15,34 @@ description: "A Política de Privacidade explica quais informações privacidade
 <p>mas não incluem:</p>
 <ul>
   <li>Produtos ou serviços que possuem uma política de privacidade separada.</li>
-  <li>Produtos de terceiros. Esses são produtos de terceiros ou serviços que você possa vir a descobrir em nosso site ou outros serviços oficiais que oferecemos. O time Privacidade Digital não pode garantir sua privacidade em sites fora de nosso controle. Você sempre deve revisar as políticas e termos de produtos e serviços de terceiros para garantir que se sinta confortável com as formas que eles coletam e usam suas informações.</li>
+  <li>Produtos de terceiros. Esses são produtos de terceiros ou serviços que você possa vir a descobrir em nosso site ou outros serviços oficiais que oferecemos. Nosso time não pode garantir sua privacidade em sites fora de nosso controle. Você sempre deve revisar as políticas e termos de produtos e serviços de terceiros para garantir que se sinta confortável com as formas que eles coletam e usam suas informações.</li>
 </ul>
 
-<!--<h2>Website Visitors</h2>
-<p>Like most website operators, privacytoolsIO collects non-personally-identifying information of the sort that web
-  browsers and servers typically make available,
-  such as the browser type, language preference, referring site, and the date and time of each visitor request.
-  privacytoolsIO's purpose in collecting
-  non-personally identifying information is to better understand how its visitors use its website and related services.
-  From time to time, privacytoolsIO may release non-personally-identifying information in the aggregate, e.g.,
-  by publishing a report on trends in the usage of its website.</p>
+<h2>Visitantes do Site</h2>
+<p>Ao contrário da maioria dos sites da internet, nós não coletamos nenhuma informação de nossos visitantes, nem mesmo as chamadas "informações não identificáveis",
+  como o tipo do seu navegador web, preferências de linguagem, origem do acesso, e data e hora da requisição web.</p>
 
-<p>privacytoolsIO also collects potentially personally-identifying information like Internet Protocol (IP) addresses.
-  privacytoolsIO does not use such information to identify its visitors, however, and does not disclose such
-  information,
-  other than under the same circumstances that it uses and discloses personally-identifying information, as described
-  below.</p>
+<h2>Coleta de Informações Identificáveis</h2>
 
-<h2>Opting Out of Website Tracking</h2>
+<p>Certos visitantes do site www.privacidade.digital podem escolher interagir de forma que seja necessária a coleta de informações que possam vir a identificá-los como indivíduo.
+  No entanto, ainda não fornecemos nenhum serviço que exija o mesmo.</p>
 
-<p>privacytoolsIO uses a self-hosted Matomo install to track visitor data. You can opt out entirely using the form
-  below. This form may not function correctly with
-  an ad blocker enabled.</p>
+<h2>Proteção de Informações Identificáveis</h2>
 
-<iframe style="border: 1; height: 120px; width: 100%;"
-  src="https://stats.privacytools.io/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=&fontColor=212529&fontSize=1rem&fontFamily=-apple-system%2CBlinkMacSystemFont%2C%22Segoe%20UI%22%2CRoboto%2C%22Helvetica%20Neue%22%2CArial%2Csans-serif%2C%22Apple%20Color%20Emoji%22%2C%22Segoe%20UI%20Emoji%22%2C%22Segoe%20UI%20Symbol%22%2C%22Noto%20Color%20Emoji%22"></iframe>
+<p>Quando e se o site passar a coletar tais informações, nossa equipe nunca irá alugá-las, vendê-las, ou fornecê-las para terceiros.</p>
 
-<p>privacytoolsIO respects your Do Not Track setting in your browser. Users with Do Not Track enabled will not be
-  tracked by any of our platforms.
-  You are also free to block stats.privacytools.io using whatever method you prefer with no detrimental effects on your
-  experience using our services.</p>-->
+<h2>Cookies</h2>
 
-<!--<h2>Gathering of Personally-Identifying Information</h2>
-
-<p>Certain visitors to privacytoolsIO's websites choose to interact with privacytoolsIO in ways that require
-  privacytoolsIO to gather personally-identifying information.
-  The amount and type of information that privacytoolsIO gathers depends on the nature of the interaction. For example,
-  we ask visitors who use our <a href="https://social.privacytools.io/">Mastodon service</a>
-  to provide a username and email address. In each case, privacytoolsIO collects such information only as in necessary
-  or appropriate to fulfill the purpose of the
-  visitor’s interaction with privacytoolsIO. privacytoolsIO does not disclose personally-identifying information other
-  than as described below. And visitors can always
-  refuse to supply personally-identifying information, with the caveat that it may prevent them from engaging in certain
-  website-related activities.</p>-->
-
-<!--<h2>Protection of Personally-Identifying Information</h2>
-
-<p>privacytoolsIO will never rent, sell, nor give away potentially personally-identifying and personally-identifying
-  information to any third parties.</p>
-
-<p>If you are a registered user of a privacytoolsIO service such as Mastodon or PeerTube, privacytoolsIO may
-  occasionally send you an email to tell you about new features,
-  solicit your feedback, or just keep you up to date with what’s going on with the service and the privacytoolsIO
-  organization.
-  We expect to keep this type of email to a minimum.</p>
-
-<p>privacytoolsIO takes all measures reasonably necessary to protect against the unauthorized access, use, alteration,
-  or destruction of potentially personally-identifying and personally-identifying information.</p>
-
-<h2>Aggregated Statistics</h2>
-
-<p>privacytoolsIO may collect statistics about the behavior of visitors to its websites, and may reveal generalized
-  statistics related to a variety of our services.</p>-->
-
-<!--<h2>Cookies</h2>
-
-<p>A cookie is a string of information that a website stores on a visitor’s computer, and that the visitor’s browser
-  provides to the website each time the visitor returns.
-  privacytoolsIO uses cookies to help privacytoolsIO track visitor statistics, a visitor's usage of the privacytoolsIO
-  website or services, and their services preferences.
-  privacytoolsIO visitors who do not wish to have cookies placed on their computers should set their browsers to refuse
-  cookies before using privacytoolsIO's websites,
-  with the drawback that certain features of privacytoolsIO's websites may not function properly without the aid of
-  cookies.</p>-->
+<p>Um cookie é uma string de informação que um site armazena no computador de seu visitante, e que o navegador do visitante reenvia para o site cada vez que o visitante retorna.
+  Nosso site ainda não utiliza nenhuma funcionalidade que precisa da utilização de cookies.</p>
 
 <h2>Mudanças na Política de Privacidade</h2>
 
-<p>Apesar da maioria das mudanças serem pequenas em sua maioria, o time Privacidade Digital pode mudar sua Política de Privacidade de tempos em tempos, discretamente. Nós encorajamos nossos visitantes a verificar esta página frequentemente por mudanças da Política de Privacidade. O uso contínuo deste site após quaisquer mudanças desta Política de Privacidade irá constituir sua aceitação a tais mudanças.</p>
+<p>Apesar da maioria das mudanças serem pequenas, a equipe Privacidade Digital pode mudar sua Política de Privacidade de tempos em tempos, discretamente. Nós encorajamos nossos visitantes a verificar esta página frequentemente por mudanças na Política de Privacidade. O uso contínuo deste site após quaisquer modificações nesta Política de Privacidade irá constituir sua aceitação às modificações.</p>
+
+<p>No entanto, nossa equipe pode criar funcionalidades novas para o site, o que pode provocar mudanças drásticas nesta política, o que será divulgado pela equipe. Além disso, você pode acompanhar toda e qualquer mudança feita neste site, incluindo sua política de privacidade, <a href="https://github.com/PrivacidadeDigital/privacidade.digital/commits/master">através do GitHub</a>.</p>
 
 <h2>Entre em Contato</h2>
 
-<p>Se você tem alguma dúvida ou qualquer questão sobre esta política de privacidade ou os dados que coletamos, sinta-se livre a <a href="https://github.com/PrivacidadeDigital/privacidade.digital/issues">abrir um issue no GitHub</a>.
+<p>Se você tem alguma dúvida ou deseja levantar qualquer questão sobre esta política de privacidade e os dados que coletamos, sinta-se livre para <a href="https://github.com/PrivacidadeDigital/privacidade.digital/issues">abrir um issue no GitHub</a>.
 </p>


### PR DESCRIPTION
* Melhorias nas palavras utilizadas para descrever a política de privacidade.
* Novas seções sobre visitantes do site, coleta e proteção de dados, e cookies.
* Adicionar link para os commits do site, para que os visitantes averiguem toda e qualquer modificação.
* Remoção de comentários e partes específicas do projeto original em Inglês.