### PR TITLE
Trocar ordem alfabética nos menus das páginas do site

### DIFF
--- a/pages/browsers.html
+++ b/pages/browsers.html
@@ -10,11 +10,11 @@ pode usar para melhorar sua privacidade."
 
 <div class="card card-list">
   <ul class="list-group list-group-flush">
-    <li class="list-group-item"><a href="/navegadores/#navegador"><i class="fas fa-check fa-fw"></i> Recomendações de Navegador</a></li>
-    <li class="list-group-item"><a href="/navegadores/#impressao_digital"><i class="fas fa-fingerprint fa-fw"></i> Impressão Digital do Navegador</a></li>
-    <li class="list-group-item"><a href="/navegadores/#webrtc"><i class="far fa-eye fa-fw"></i> Vazamento de IP por WebRTC</a></li>
     <li class="list-group-item"><a href="/navegadores/#extensoes"><i class="far fa-list-alt fa-fw"></i> Extensões de Privacidade para o Firefox</a></li>
     <li class="list-group-item"><a href="/navegadores/#about_config"><i class="fas fa-wrench fa-fw"></i> Firefox: Configurações relacionadas à privacidade</a></li>
+    <li class="list-group-item"><a href="/navegadores/#impressao_digital"><i class="fas fa-fingerprint fa-fw"></i> Impressão Digital do Navegador</a></li>
+    <li class="list-group-item"><a href="/navegadores/#navegador"><i class="fas fa-check fa-fw"></i> Recomendações de Navegador</a></li>
+    <li class="list-group-item"><a href="/navegadores/#webrtc"><i class="far fa-eye fa-fw"></i> Vazamento de IP por WebRTC</a></li>
   </ul>
 </div>
 

--- a/pages/os.html
+++ b/pages/os.html
@@ -10,12 +10,12 @@ que recomendamos e escolha a melhor opção para cada dispositivo que você usa.
 
 <div class="card card-list">
   <ul class="list-group list-group-flush">
-    <li class="list-group-item"><a href="/sistemas-operacionais/#so"><i class="fas fa-th-large fa-fw"></i> Sistemas Operacionais de PC</a></li>
-    <li class="list-group-item"><a href="/sistemas-operacionais/#so_live"><i class="fas fa-compact-disc fa-fw"></i> Sistemas Operacionais Live CD</a></li>
-    <li class="list-group-item"><a href="/sistemas-operacionais/#so_movel"><i class="fas fa-mobile-alt fa-fw"></i> Sistemas Operacionais Móveis</a></li>
     <li class="list-group-item"><a href="/sistemas-operacionais/#extensoes_android"><i class="fas fa-th fa-fw"></i> Extensões de Privacidade para Android</a></li>
     <li class="list-group-item"><a href="/sistemas-operacionais/#firmware"><i class="fas fa-signal fa-fw"></i> Firmware para Roteadores</a></li>
     <li class="list-group-item"><a href="/sistemas-operacionais/#win10"><i class="far fa-thumbs-down fa-fw"></i> Não use Windows 10</a></li>
+    <li class="list-group-item"><a href="/sistemas-operacionais/#so_live"><i class="fas fa-compact-disc fa-fw"></i> Sistemas Operacionais Live CD</a></li>
+    <li class="list-group-item"><a href="/sistemas-operacionais/#so_movel"><i class="fas fa-mobile-alt fa-fw"></i> Sistemas Operacionais Móveis</a></li>
+    <li class="list-group-item"><a href="/sistemas-operacionais/#so"><i class="fas fa-th-large fa-fw"></i> Sistemas Operacionais de PC</a></li>
   </ul>
 </div>
 

--- a/pages/providers.html
+++ b/pages/providers.html
@@ -12,14 +12,14 @@ nossas recomendações para uma variedade de serviços."
 
 <div class="card card-list">
   <ul class="list-group list-group-flush">
-    <li class="list-group-item"><a href="/provedores/#ukusa/"><i class="fab fa-creative-commons-nc fa-fw"></i> Evite serviços hospedado nos EUA e Reino Unido</a></li>
-    <li class="list-group-item"><a href="/provedores/vpn/"><i class="far fa-eye-slash"></i> VPNs para Privacidade e Segurança</a></li>
-    <li class="list-group-item"><a href="/provedores/email/"><i class="fas fa-mail-bulk"></i> Email Seguro</a></li>
-    <li class="list-group-item"><a href="/provedores/busca/"><i class="fab fa-searchengin"></i> Motores de Busca</a></li>
     <li class="list-group-item"><a href="/provedores/armazenamento-na-nuvem/"><i class="fas fa-cloud"></i> Armazenamento na Nuvem</a></li>
-    <li class="list-group-item"><a href="/provedores/redes-sociais/"><i class="fas fa-expand-arrows-alt"></i> Redes Sociais</a></li>
     <li class="list-group-item"><a href="/provedores/dns/"><i class="fa fa-tasks"></i> DNS</a></li>
+    <li class="list-group-item"><a href="/provedores/email/"><i class="fas fa-mail-bulk"></i> Email Seguro</a></li>
     <li class="list-group-item"><a href="/provedores/hospedagem/"><i class="fas fa-database"></i> Hospedagem</a></li>
+    <li class="list-group-item"><a href="/provedores/busca/"><i class="fab fa-searchengin"></i> Motores de Busca</a></li>
+    <li class="list-group-item"><a href="/provedores/redes-sociais/"><i class="fas fa-expand-arrows-alt"></i> Redes Sociais</a></li>
+    <li class="list-group-item"><a href="/provedores/vpn/"><i class="far fa-eye-slash"></i> VPNs para Privacidade e Segurança</a></li>
+    <li class="list-group-item"><a href="/provedores/#ukusa/"><i class="fab fa-creative-commons-nc fa-fw"></i> Evite serviços hospedado nos EUA e Reino Unido</a></li>
   </ul>
 </div>
 

--- a/pages/software.html
+++ b/pages/software.html
@@ -9,18 +9,18 @@ description: "Descubra uma variedade de softwares open source feitos para proteg
 
 <div class="card card-list">
   <ul class="list-group list-group-flush">
-    <li class="list-group-item"><a href="/software/email/"><i class="fas fa-envelope"></i> Clientes de Email</a></li>
     <li class="list-group-item"><a href="/software/email/#mensagens"><i class="fas fa-random"></i> Alternativas ao Email</a></li>
-    <li class="list-group-item"><a href="/software/mensagens/"><i class="fab fa-telegram-plane"></i> Mensagens Instantâneas</a></li>
     <li class="list-group-item"><a href="/software/chamadas/"><i class="fas fa-phone"></i> Conversa de Vídeo & Voz</a></li>
+    <li class="list-group-item"><a href="/software/email/"><i class="fas fa-envelope"></i> Clientes de Email</a></li>
     <li class="list-group-item"><a href="/software/compartilhamento-de-arquivos/"><i class="fas fa-file-export"></i> Compartilhamento de Arquivos</a></li>
-    <li class="list-group-item"><a href="/software/nuvem/"><i class="fas fa-hdd"></i> Servidor Auto-Hospedado no nuvem</a></li>
-    <li class="list-group-item"><a href="/software/sincronizacao-de-arquivos/"><i class="fas fa-copy"></i> Sincronização Segura de Arquivos</a></li>
-    <li class="list-group-item"><a href="/software/senhas/"><i class="fas fa-user-lock"></i> Gerenciador de Senhas</a></li>
-    <li class="list-group-item"><a href="/software/calendario-e-contatos/"><i class="far fa-calendar-alt"></i> Sincronização de Calendário e Contatos</a></li>
     <li class="list-group-item"><a href="/software/encriptacao/"><i class="fas fa-lock"></i> Encriptação de Arquivos</a></li>
-    <li class="list-group-item"><a href="/software/redes/"><i class="fas fa-user-secret"></i> Redes Independentes</a></li>
-    <li class="list-group-item"><a href="/software/notas/"><i class="far fa-sticky-note"></i> Notas Digitais</a></li>
     <li class="list-group-item"><a href="/software/produtividade/"><i class="fas fa-briefcase"></i> Ferramentas de Produtividade</a></li>
+    <li class="list-group-item"><a href="/software/senhas/"><i class="fas fa-user-lock"></i> Gerenciador de Senhas</a></li>
+    <li class="list-group-item"><a href="/software/mensagens/"><i class="fab fa-telegram-plane"></i> Mensagens Instantâneas</a></li>
+    <li class="list-group-item"><a href="/software/notas/"><i class="far fa-sticky-note"></i> Notas Digitais</a></li>
+    <li class="list-group-item"><a href="/software/redes/"><i class="fas fa-user-secret"></i> Redes Independentes</a></li>
+    <li class="list-group-item"><a href="/software/nuvem/"><i class="fas fa-hdd"></i> Servidor Auto-Hospedado no nuvem</a></li>
+    <li class="list-group-item"><a href="/software/calendario-e-contatos/"><i class="far fa-calendar-alt"></i> Sincronização de Calendário e Contatos</a></li>
+    <li class="list-group-item"><a href="/software/sincronizacao-de-arquivos/"><i class="fas fa-copy"></i> Sincronização Segura de Arquivos</a></li>
   </ul>
 </div>


### PR DESCRIPTION
Relacionado: #41 

Nota: a página "Evite serviços hospedados nos EUA e Reino Unido" não fez parte da ordenação no menu de Provedores, porque acredito que se trata de uma "seção especial" do site.